### PR TITLE
Updated workflow to run on main, feature, and hotfix branches

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,10 +1,11 @@
 name: CI/CD
 
 on:
-    push:
-        branches: 
-            - master
-            - ft/*
+  push:
+    branches: 
+    - 'main'
+    - 'ft/*'
+    - 'hf/*'
 
 permissions:
   contents: read

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,8 @@ on:
     - 'main'
     - 'ft/*'
     - 'hf/*'
+  schedule:
+    - cron: 0 2 * * *
 
 permissions:
   contents: read


### PR DESCRIPTION
Workflow was not running on main branch because it was not correctly configured. Changed to run on `main`, `ft/*`, and `hf/*` branches.