### PR TITLE
 Fix: header size on mobile devices

### DIFF
--- a/src/components/client/MobileMenu.tsx
+++ b/src/components/client/MobileMenu.tsx
@@ -15,8 +15,6 @@ export const MobileMenu = ({ onClose }: MobileMenuProps) => {
       <button className="mobile-menu-button" onClick={menuToggle}>
         <span className="sr-only">Open menu</span>
         <svg
-          width="24"
-          height="24"
           viewBox="0 0 24 24"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
@@ -48,8 +46,6 @@ export const MobileMenu = ({ onClose }: MobileMenuProps) => {
         <button className="mobile-menu-close" onClick={menuToggle}>
           <span className="sr-only">Close menu</span>
           <svg
-            width="24"
-            height="24"
             viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -380,8 +380,10 @@ body {
   border: none;
   cursor: pointer;
   position: absolute;
-  top: 24px;
+  top: 12px;
   right: 24px;
+  width: 48px;
+  height: 48px;
 }
 
 .mobile-nav-links {
@@ -400,8 +402,28 @@ body {
 /* Responsive Design */
 @media (max-width: 768px) {
   img {
-    width: 100%;
-    height: auto;
+    width: 48px;
+    height: 48px;
+  }
+
+  .header {
+    padding: 12px 0;
+  }
+  
+  .header-content {
+    gap: 8px;
+  }
+  
+  .logo-section {
+    gap: 12px;
+  }
+  
+  .logo-text h1 {
+    font-size: 18px;
+  }
+  
+  .logo-subtitle {
+    font-size: 12px;
   }
 
   .nav-links {
@@ -430,11 +452,15 @@ body {
   
   .mobile-menu-button {
     display: block;
+    width: 48px;
+    height: 48px;
   }
+  
 
   .footer-grid {
     gap: 24px;
   }
+  
 }
 
 .why-join-slack {


### PR DESCRIPTION
Fixes #25
Removed "width" properties from svg images in MobileMenu.tsx, so the sizes can be modified directly in stylesheets (globals.css). Changed sizes on toggle buttons to 48px (before it was svg width 24). Changed position of "close mobile menu button", so it's it's in the same position as the open button after size change. Changed logo image to 48px (only for mobile), so it's proportional to toggle button.  