### PR TITLE
fix: Code page - open links in new tabs

### DIFF
--- a/pages/code-of-conduct.md
+++ b/pages/code-of-conduct.md
@@ -63,5 +63,5 @@ If you believe that someone is violating the code of conduct, or have any other 
 
 ## 10. License and Attribution
 
-This Code of Conduct is adapted from the [Winnipeg.rb Code of Conduct](https://winnipegrb.org/code_of_conduct.html), which is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/).
+This Code of Conduct is adapted from the <a href="https://winnipegrb.org/code_of_conduct.html" target="_blank">Winnipeg.rb Code of Conduct</a>, which is licensed under a <a href="http://creativecommons.org/licenses/by-sa/3.0/" target="_blank">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.
 

--- a/src/components/partials/main-page/CurrentSponsor.tsx
+++ b/src/components/partials/main-page/CurrentSponsor.tsx
@@ -26,7 +26,11 @@ export const CurrentSponsor = ({
           <p>{description}</p>
         </div>
       </div>
-      <a href={link} class="button button-primary upcoming-event-button">
+      <a 
+        href={link}
+        target="_blank"
+        class="button button-primary upcoming-event-button"
+      >
         Visit {name}
       </a>
     </div>


### PR DESCRIPTION
Add target="_blank" to external links in Code of Conduct

- Modified external links to open in new browser tabs instead of the same window